### PR TITLE
Remove JCenter repository 

### DIFF
--- a/retromock/build.gradle
+++ b/retromock/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
JCenter wasn't used by any dependencies, removing it from `repositories {}` is enough 