### PR TITLE
Fix: Dependency conflict due to not using compile only

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Then, you can include the library in your module's `build.gradle` or `build.grad
 **Groovy**
 
 ```groovy
-implementation 'com.infinum:retromock:1.2.0'
+implementation 'com.infinum:retromock:1.2.1'
 ```
 
 **KotlinDSL**
 
 ```kotlin
-implementation("com.infinum:retromock:1.2.0")
+implementation("com.infinum:retromock:1.2.1")
 ```
 
 ## Usage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ junit = "5.11.2"
 kotlin = "2.1.0"
 mockito = "5.14.1"
 retrofit = "2.11.0"
-retromock = "1.2.0"
+retromock = "1.2.1"
 moshi = "1.15.1"
 spotbugs = "6.0.27"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,10 +52,10 @@ jacoco {
 }
 
 dependencies {
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.kotlin.coroutines)
+    compileOnly(libs.kotlin.stdlib)
+    compileOnly(libs.kotlin.coroutines)
 
-    implementation(libs.google.annotations)
+    compileOnly(libs.google.annotations)
 
     implementation(libs.retrofit)
 

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -2,7 +2,7 @@ task generateReadme {
     doFirst {
         def readmeFile = new File("${project.rootDir}/README.md")
         def content = readmeFile.text
-        content = content.replaceAll("'com\\.infinum:retromock:.+?'", "'com.infinum:retromock:${libs.versions.retromock.get()}'")
+        content = content.replaceAll("com.infinum:retromock:\\d+\\.\\d+\\.\\d+", "com.infinum:retromock:${libs.versions.retromock.get()}")
         readmeFile.setText(content)
     }
 }


### PR DESCRIPTION
## Summary

I have managed to replicate issue https://github.com/infinum/Retromock/issues/32 on some other project
The fix for the issue is to include dependencies with `compileOnly`.

**Related issue**:  https://github.com/infinum/Retromock/issues/32

## Changes

Replace `implementation` with `compileOnly` for most dependecies
Version bump (+ fix for auto generating readme version)


### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

After making changes I published lib to `MavenLocal` and included it on the same project where I managed to replace issue. Version with this fixes doesn't have the issue.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [x] I have added necessary tests for the changes introduced (if applicable).
- [x] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

After this PR is merged I will publish hotfix release both on `co.infinum` and `com.infinum `namespaces
